### PR TITLE
Remove C compiler dependency on nightly, add baremetal find_cfi

### DIFF
--- a/unwind/Cargo.toml
+++ b/unwind/Cargo.toml
@@ -15,3 +15,6 @@ gcc = "0.3.52"
 [dev-dependencies]
 backtrace = "0.3"
 env_logger = "0.4"
+
+[features]
+nightly = []

--- a/unwind/build.rs
+++ b/unwind/build.rs
@@ -1,7 +1,13 @@
 extern crate gcc;
+use std::env;
 
 fn main() {
-    gcc::Build::new()
-               .file("src/unwind_helper.c")
-               .compile("unwind_helper");
+    match env::var("CARGO_FEATURE_NIGHTLY") {
+        Err(env::VarError::NotPresent) => {
+            gcc::Build::new()
+                       .file("src/unwind_helper.c")
+                       .compile("unwind_helper");
+        },
+        _ => ()
+    }
 }

--- a/unwind/src/find_cfi/baremetal.rs
+++ b/unwind/src/find_cfi/baremetal.rs
@@ -1,0 +1,29 @@
+use range::AddrRange;
+use super::EhRef;
+
+extern "C" {
+    static __text_start: usize;
+    static __text_end: usize;
+    static __ehframehdr_start: usize;
+    static __ehframehdr_end: usize;
+}
+
+pub fn find_cfi_sections() -> Vec<EhRef> {
+    let mut cfi: Vec<EhRef> = Vec::new();
+    unsafe {
+        // Safety: None of those are actual accesses - we only get the address
+        // of those values.
+        let text_start = &__text_start as *const _ as u64;
+        let text_end = &__text_end as *const _ as u64;
+        let cfi_start = &__ehframehdr_start as *const _ as u64;
+        let cfi_end = &__ehframehdr_end as *const _ as u64;
+
+        cfi.push(EhRef {
+            obj_base: 0,
+            text: AddrRange { start: text_start, end: text_end },
+            cfi: AddrRange { start: cfi_start, end: cfi_end },
+        });
+    }
+    trace!("CFI sections: {:?}", cfi);
+    cfi
+}

--- a/unwind/src/find_cfi/ld.rs
+++ b/unwind/src/find_cfi/ld.rs
@@ -1,7 +1,8 @@
 use libc::{c_void, c_int, c_char};
 use std::ffi::CStr;
 use std::{slice, mem};
-use super::range::AddrRange;
+use range::AddrRange;
+use super::EhRef;
 
 #[repr(C)]
 struct DlPhdrInfo {
@@ -43,13 +44,6 @@ const PT_LOAD: u32 = 1;
 type PhdrCb = extern "C" fn(info: *const DlPhdrInfo, size: usize, data: *mut c_void) -> c_int;
 extern "C" {
     fn dl_iterate_phdr(callback: PhdrCb, data: *mut c_void) -> c_int;
-}
-
-#[derive(Debug)]
-pub struct EhRef {
-    pub obj_base: u64,
-    pub text: AddrRange,
-    pub cfi: AddrRange,
 }
 
 extern "C" fn callback(info: *const DlPhdrInfo, size: usize, data: *mut c_void) -> c_int {

--- a/unwind/src/find_cfi/mod.rs
+++ b/unwind/src/find_cfi/mod.rs
@@ -1,0 +1,19 @@
+use range::AddrRange;
+
+#[derive(Debug)]
+pub struct EhRef {
+    pub obj_base: u64,
+    pub text: AddrRange,
+    pub cfi: AddrRange,
+}
+
+#[cfg(unix)]
+#[path = "ld.rs"]
+mod imp;
+
+#[cfg(not(unix))]
+#[path = "baremetal.rs"]
+mod imp;
+
+
+pub use self::imp::find_cfi_sections;

--- a/unwind/src/glue.rs
+++ b/unwind/src/glue.rs
@@ -3,8 +3,60 @@ use registers::{Registers, DwarfRegister};
 
 #[allow(improper_ctypes)] // trampoline just forwards the ptr
 extern "C" {
+    #[cfg(not(feature = "nightly"))]
     pub fn unwind_trampoline(payload: *mut UnwindPayload);
+    #[cfg(not(feature = "nightly"))]
     fn unwind_lander(regs: *const LandingRegisters);
+}
+
+#[cfg(feature = "nightly")]
+#[naked]
+pub unsafe extern fn unwind_trampoline(_payload: *mut UnwindPayload) {
+    asm!("
+     movq %rsp, %rsi
+     .cfi_def_cfa rsi, 8
+     pushq %rbp
+     .cfi_offset rbp, -16
+     pushq %rbx
+     pushq %r12
+     pushq %r13
+     pushq %r14
+     pushq %r15
+     movq %rsp, %rdx
+     subq 0x08, %rsp
+     .cfi_def_cfa rsp, 0x40
+     call unwind_recorder
+     addq 0x38, %rsp
+     .cfi_def_cfa rsp, 8
+     ret
+     ");
+    ::std::hint::unreachable_unchecked();
+}
+
+#[cfg(feature = "nightly")]
+#[naked]
+unsafe extern fn unwind_lander(_regs: *const LandingRegisters) {
+    asm!("
+     movq %rdi, %rsp
+     popq %rax
+     popq %rbx
+     popq %rcx
+     popq %rdx
+     popq %rdi
+     popq %rsi
+     popq %rbp
+     popq %r8
+     popq %r9
+     popq %r10
+     popq %r11
+     popq %r12
+     popq %r13
+     popq %r14
+     popq %r15
+     movq 0(%rsp), %rsp
+     ret // HYPERSPACE JUMP :D
+     ");
+    ::std::hint::unreachable_unchecked();
 }
 
 #[repr(C)]

--- a/unwind/src/lib.rs
+++ b/unwind/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "nightly", feature(asm, naked_functions))]
+
 extern crate gimli;
 extern crate libc;
 extern crate fallible_iterator;


### PR DESCRIPTION
Fixes #3 and #4 

Uses naked functions and inline asm to remove dependency on C compiler. This is enabled with a nightly feature.

Uses target cfg to decide which find_cfi impl to use. Defaults to the ld-based one on unix, and baremetal otherwise.

Is object_base still used for anything? A quick grep only reveals it being set. but never used.