### PR TITLE
Try to determine the size of the eh_frame section

### DIFF
--- a/unwind/src/find_cfi/baremetal.rs
+++ b/unwind/src/find_cfi/baremetal.rs
@@ -6,6 +6,7 @@ extern "C" {
     static __text_end: usize;
     static __ehframehdr_start: usize;
     static __ehframehdr_end: usize;
+    static __ehframe_end: usize;
 }
 
 pub fn find_cfi_sections() -> Vec<EhRef> {
@@ -17,11 +18,13 @@ pub fn find_cfi_sections() -> Vec<EhRef> {
         let text_end = &__text_end as *const _ as u64;
         let cfi_start = &__ehframehdr_start as *const _ as u64;
         let cfi_end = &__ehframehdr_end as *const _ as u64;
+        let eh_frame_end = &__ehframe_end as *const _ as u64;
 
         cfi.push(EhRef {
             obj_base: 0,
             text: AddrRange { start: text_start, end: text_end },
             cfi: AddrRange { start: cfi_start, end: cfi_end },
+            ehframe_end,
         });
     }
     trace!("CFI sections: {:?}", cfi);

--- a/unwind/src/find_cfi/mod.rs
+++ b/unwind/src/find_cfi/mod.rs
@@ -5,6 +5,7 @@ pub struct EhRef {
     pub obj_base: u64,
     pub text: AddrRange,
     pub cfi: AddrRange,
+    pub ehframe_end: u64,
 }
 
 #[cfg(unix)]

--- a/unwind/src/lib.rs
+++ b/unwind/src/lib.rs
@@ -60,7 +60,7 @@ impl Default for DwarfUnwinder {
                 let eh_frame_hdr = EhFrameHdr::new(eh_frame_hdr, NativeEndian).parse(&bases, 8).unwrap();
 
                 let cfi_addr = deref_ptr(eh_frame_hdr.eh_frame_ptr());
-                let cfi_sz = 0x10000000; // FIXME HACK
+                let cfi_sz = er.ehframe_end.saturating_sub(cfi_addr);
 
                 let eh_frame: &'static [u8] = std::slice::from_raw_parts(cfi_addr as *const u8, cfi_sz as usize);
                 trace!("cfi at {:p} sz {:x}", cfi_addr as *const u8, cfi_sz);


### PR DESCRIPTION
We can do slightly better by limiting it to only the segment that contains the start of eh_frame, but that requires parsing eh_frame_hdr first.

cc @roblabla for the baremetal change.