### PR TITLE
Fix correctness test

### DIFF
--- a/unwind/tests/correctness.rs
+++ b/unwind/tests/correctness.rs
@@ -25,24 +25,32 @@ fn test_frame_3() {
         println!("{:08x}", i);
     }
     println!();
-        
-    DwarfUnwinder::default().trace(move |frames| {
+
+    let mut ref_trace_len = ref_trace.len();
+    // Haven't investigated why this has a trailing zero.
+    if ref_trace[ref_trace_len - 1] == 0 {
+        ref_trace_len -= 1;
+    }
+
+    let mut our_trace = Vec::new();
+
+    DwarfUnwinder::default().trace(|frames| {
         // skip 3 (unwind-rs + test_frame_3)
         frames.next().unwrap();
         frames.next().unwrap();
         frames.next().unwrap();
 
-        let mut our_trace = Vec::new();
         while let Some(_) = frames.next().unwrap() {
             our_trace.push(frames.registers()[16].unwrap() - 1);
         }
-
-        for i in &our_trace {
-            println!("{:08x}", i);
-        }
-
-        assert!(our_trace.len() > 3);
-        let ref_trace = &ref_trace[ref_trace.len() - our_trace.len()..];
-        assert_eq!(our_trace, ref_trace);
     });
+
+    for i in &our_trace {
+        println!("{:08x}", i);
+    }
+
+    let our_trace_len = our_trace.len();
+    assert!(our_trace_len > 3);
+    let ref_trace = &ref_trace[ref_trace_len - our_trace_len..][..our_trace_len];
+    assert_eq!(our_trace, ref_trace);
 }


### PR DESCRIPTION
It is using the system unwinder for the reference now that libunwind_shim is disabled by #35.

Also move the assert out of the callback, because unwinding in the callback doesn't work.

Fixes #27